### PR TITLE
HOPSWORKS-745: Make SparkSQL compatible with HopsHive

### DIFF
--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -157,6 +157,11 @@ object LivyConf {
   val SPARK_FILES = "spark.files"
   val SPARK_ARCHIVES = "spark.yarn.dist.archives"
   val SPARK_PY_FILES = "spark.submit.pyFiles"
+  val SPARK_YARN_ARCHIVE = "spark.yarn.archive"
+  val SPARK_YARN_DIST_FILES = "spark.yarn.dist.files"
+  val SPARK_YARN_DIST_JARS = "spark.yarn.dist.jars"
+  val SPARK_YARN_JAR = "spark.yarn.jar"
+  val SPARK_YARN_JARS = "spark.yarn.jars"
 
   /**
    * These are Spark configurations that contain lists of files that the user can add to
@@ -174,11 +179,11 @@ object LivyConf {
     SPARK_FILES,
     SPARK_ARCHIVES,
     SPARK_PY_FILES,
-    "spark.yarn.archive",
-    "spark.yarn.dist.files",
-    "spark.yarn.dist.jars",
-    "spark.yarn.jar",
-    "spark.yarn.jars"
+    SPARK_YARN_ARCHIVE,
+    SPARK_YARN_DIST_FILES,
+    SPARK_YARN_DIST_JARS,
+    SPARK_YARN_JAR,
+    SPARK_YARN_JARS
   )
 
   case class DepConf(

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -289,16 +289,31 @@ object InteractiveSession extends Logging {
     }
 
     def mergeHiveSiteAndHiveDeps(sparkMajorVersion: Int): Unit = {
-      val sparkFiles = conf.get("spark.files").map(_.split(",")).getOrElse(Array.empty[String])
-      hiveSiteFile(sparkFiles, livyConf) match {
+      val yarnFiles = conf.get(LivyConf.SPARK_YARN_DIST_FILES).map(_.split(",")).getOrElse(Array.empty[String])
+      val sparkFiles = conf.get(LivyConf.SPARK_FILES).map(_.split(",")).getOrElse(Array.empty[String])
+      var files = Array.empty[String]
+      if (!sparkFiles.isEmpty || yarnFiles.isEmpty) files = sparkFiles else files = yarnFiles
+      hiveSiteFile(files, livyConf) match {
         case (_, true) =>
           debug("Enable HiveContext because hive-site.xml is found in user request.")
-          mergeConfList(datanucleusJars(livyConf, sparkMajorVersion), LivyConf.SPARK_JARS)
+          if (conf.get(LivyConf.SPARK_JARS) != None || conf.get(LivyConf.SPARK_YARN_JARS) == None) {
+            mergeConfList(datanucleusJars(livyConf, sparkMajorVersion), LivyConf.SPARK_JARS)
+          } else {
+            mergeConfList(datanucleusJars(livyConf, sparkMajorVersion), LivyConf.SPARK_YARN_JARS)
+          }
         case (Some(file), false) =>
           debug("Enable HiveContext because hive-site.xml is found under classpath, "
             + file.getAbsolutePath)
-          mergeConfList(List(file.getAbsolutePath), LivyConf.SPARK_FILES)
-          mergeConfList(datanucleusJars(livyConf, sparkMajorVersion), LivyConf.SPARK_JARS)
+          if (!sparkFiles.isEmpty || yarnFiles.isEmpty) {
+            mergeConfList(List(file.getAbsolutePath), LivyConf.SPARK_FILES)
+          } else {
+            mergeConfList(List(file.getAbsolutePath), LivyConf.SPARK_YARN_DIST_FILES)
+          }
+          if (conf.get(LivyConf.SPARK_JARS) != None || conf.get(LivyConf.SPARK_YARN_JARS) == None) {
+            mergeConfList(datanucleusJars(livyConf, sparkMajorVersion), LivyConf.SPARK_JARS)
+          } else {
+            mergeConfList(datanucleusJars(livyConf, sparkMajorVersion), LivyConf.SPARK_YARN_JARS)
+          }
         case (None, false) =>
           warn("Enable HiveContext but no hive-site.xml found under" +
             " classpath or user request.")
@@ -335,7 +350,11 @@ object InteractiveSession extends Logging {
       LivySparkUtils.formatSparkVersion(livyConf.get(LivyConf.LIVY_SPARK_VERSION))
     val scalaVersion = livyConf.get(LivyConf.LIVY_SPARK_SCALA_VERSION)
 
-    mergeConfList(livyJars(livyConf, scalaVersion), LivyConf.SPARK_JARS)
+    if (conf.get(LivyConf.SPARK_JARS) != None || conf.get(LivyConf.SPARK_JARS) == None){
+      mergeConfList(livyJars(livyConf, scalaVersion), LivyConf.SPARK_JARS)
+    } else {
+      mergeConfList(livyJars(livyConf, scalaVersion), LivyConf.SPARK_YARN_JARS)
+    }
     val enableHiveContext = livyConf.getBoolean(LivyConf.ENABLE_HIVE_CONTEXT)
     // pass spark.livy.spark_major_version to driver
     builderProperties.put("spark.livy.spark_major_version", sparkMajorVersion.toString)


### PR DESCRIPTION
This commit fixes a bug in livy that yarn properties are
overriden when hive is enabled in the spark sessions.