### PR TITLE
[HOPSWORKS-1217] Use local jars for Datanucleus

### DIFF
--- a/conf/livy.conf.template
+++ b/conf/livy.conf.template
@@ -75,6 +75,11 @@
 # during session creation.
 # livy.repl.jars =
 
+# Comma-separated list of Livy Datanucleus jars. By default Livy will upload jars from its installation
+# directory every time a session is started. By caching these files in HDFS, for example, startup
+# time of sessions on YARN can be reduced.
+# livy.datanucleus.jars =
+
 # Location of PySpark archives. By default Livy will upload the file from SPARK_HOME, but
 # by caching the file in HDFS, startup time of PySpark sessions on YARN can be reduced.
 # livy.pyspark.archives =

--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -207,6 +207,8 @@ object LivyConf {
   val REPL_JARS = Entry("livy.repl.jars", null)
   // RSC related jars separated with comma.
   val RSC_JARS = Entry("livy.rsc.jars", null)
+  // Datanucleus related jars separated with comma.
+  val DATANUCLEUS_JARS = Entry("livy.datanucleus.jars", null)
 
   // How long to check livy session leakage
   val YARN_APP_LEAKAGE_CHECK_TIMEOUT = Entry("livy.server.yarn.app-leakage.check-timeout", "600s")

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -195,31 +195,35 @@ object InteractiveSession extends Logging {
     }
 
     def datanucleusJars(livyConf: LivyConf, sparkMajorVersion: Int): Seq[String] = {
-      if (sys.env.getOrElse("LIVY_INTEGRATION_TEST", "false").toBoolean) {
-        // datanucleus jars has already been in classpath in integration test
-        Seq.empty
-      } else {
-        val sparkHome = livyConf.sparkHome().get
-        val libdir = sparkMajorVersion match {
-          case 2 =>
-            if (new File(sparkHome, "RELEASE").isFile) {
-              new File(sparkHome, "jars")
-            } else {
-              new File(sparkHome, "assembly/target/scala-2.11/jars")
-            }
-          case v =>
-            throw new RuntimeException(s"Unsupported Spark major version: $sparkMajorVersion")
-        }
-        val jars = if (!libdir.isDirectory) {
-          Seq.empty[String]
+      Option(livyConf.get(LivyConf.DATANUCLEUS_JARS)).map { jars =>
+        jars.split(",").toList
+      }.getOrElse {
+        if (sys.env.getOrElse("LIVY_INTEGRATION_TEST", "false").toBoolean) {
+          // datanucleus jars has already been in classpath in integration test
+          Seq.empty
         } else {
-          libdir.listFiles().filter(_.getName.startsWith("datanucleus-"))
-            .map(_.getAbsolutePath).toSeq
+          val sparkHome = livyConf.sparkHome().get
+          val libdir = sparkMajorVersion match {
+            case 2 =>
+              if (new File(sparkHome, "RELEASE").isFile) {
+                new File(sparkHome, "jars")
+              } else {
+                new File(sparkHome, "assembly/target/scala-2.11/jars")
+              }
+            case v =>
+              throw new RuntimeException(s"Unsupported Spark major version: $sparkMajorVersion")
+          }
+          val jars = if (!libdir.isDirectory) {
+            Seq.empty[String]
+          } else {
+            libdir.listFiles().filter(_.getName.startsWith("datanucleus-"))
+              .map(_.getAbsolutePath).toSeq
+          }
+          if (jars.isEmpty) {
+            warn("datanucleus jars can not be found")
+          }
+          jars
         }
-        if (jars.isEmpty) {
-          warn("datanucleus jars can not be found")
-        }
-        jars
       }
     }
 
@@ -290,11 +294,6 @@ object InteractiveSession extends Logging {
       hiveSiteFile(files, livyConf) match {
         case (_, true) =>
           debug("Enable HiveContext because hive-site.xml is found in user request.")
-          if (conf.get(LivyConf.SPARK_JARS) != None || conf.get(LivyConf.SPARK_YARN_JARS) == None) {
-            mergeConfList(datanucleusJars(livyConf, sparkMajorVersion), LivyConf.SPARK_JARS)
-          } else {
-            mergeConfList(datanucleusJars(livyConf, sparkMajorVersion), LivyConf.SPARK_YARN_JARS)
-          }
         case (Some(file), false) =>
           debug("Enable HiveContext because hive-site.xml is found under classpath, "
             + file.getAbsolutePath)
@@ -303,14 +302,14 @@ object InteractiveSession extends Logging {
           } else {
             mergeConfList(List(file.getAbsolutePath), LivyConf.SPARK_YARN_DIST_FILES)
           }
-          if (conf.get(LivyConf.SPARK_JARS) != None || conf.get(LivyConf.SPARK_YARN_JARS) == None) {
-            mergeConfList(datanucleusJars(livyConf, sparkMajorVersion), LivyConf.SPARK_JARS)
-          } else {
-            mergeConfList(datanucleusJars(livyConf, sparkMajorVersion), LivyConf.SPARK_YARN_JARS)
-          }
         case (None, false) =>
           warn("Enable HiveContext but no hive-site.xml found under" +
             " classpath or user request.")
+      }
+      if (conf.get(LivyConf.SPARK_JARS) != None || conf.get(LivyConf.SPARK_YARN_JARS) == None) {
+        mergeConfList(datanucleusJars(livyConf, sparkMajorVersion), LivyConf.SPARK_JARS)
+      } else {
+        mergeConfList(datanucleusJars(livyConf, sparkMajorVersion), LivyConf.SPARK_YARN_JARS)
       }
     }
 
@@ -344,11 +343,16 @@ object InteractiveSession extends Logging {
       LivySparkUtils.formatSparkVersion(livyConf.get(LivyConf.LIVY_SPARK_VERSION))
     val scalaVersion = livyConf.get(LivyConf.LIVY_SPARK_SCALA_VERSION)
 
-    if (conf.get(LivyConf.SPARK_JARS) != None || conf.get(LivyConf.SPARK_JARS) == None){
+    if (conf.get(LivyConf.SPARK_JARS) != None || conf.get(LivyConf.SPARK_YARN_JARS) == None) {
       mergeConfList(livyJars(livyConf, scalaVersion), LivyConf.SPARK_JARS)
     } else {
       mergeConfList(livyJars(livyConf, scalaVersion), LivyConf.SPARK_YARN_JARS)
     }
+
+    if (Option(livyConf.get(LivyConf.RSC_JARS)) != None) {
+      mergeConfList(livyConf.get(LivyConf.RSC_JARS).split(","), LivyConf.SPARK_YARN_JARS)
+    }
+
     val enableHiveContext = livyConf.getBoolean(LivyConf.ENABLE_HIVE_CONTEXT)
     // pass spark.livy.spark_major_version to driver
     builderProperties.put("spark.livy.spark_major_version", sparkMajorVersion.toString)

--- a/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
@@ -153,7 +153,7 @@ class InteractiveSessionSpec extends FunSpec
       val properties1 = InteractiveSession.prepareBuilderProp(
         Map(RSCConf.Entry.LIVY_JARS.key() -> rscJars1.mkString(",")), Spark, livyConf)
       // if rsc jars are configured both in LivyConf and RSCConf, RSCConf should take precedence.
-      properties1(RSCConf.Entry.LIVY_JARS.key()).split(",").toSet === rscJars1
+      properties1(RSCConf.Entry.LIVY_JARS.key()).split(",").toSet should equal(rscJars1)
     }
 
     it("should set datanucleus jars through livy conf") {

--- a/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
@@ -143,7 +143,7 @@ class InteractiveSessionSpec extends FunSpec
         .set(LivyConf.LIVY_SPARK_SCALA_VERSION, "2.10")
       val properties = InteractiveSession.prepareBuilderProp(Map.empty, Spark, livyConf)
       // if livy.rsc.jars is configured in LivyConf, it should be passed to RSCConf.
-      properties(RSCConf.Entry.LIVY_JARS.key()).split(",").toSet === rscJars
+      properties(RSCConf.Entry.LIVY_JARS.key()).split(",").toSet should equal(rscJars)
 
       val rscJars1 = Set(
         "foo.jar",
@@ -154,6 +154,23 @@ class InteractiveSessionSpec extends FunSpec
         Map(RSCConf.Entry.LIVY_JARS.key() -> rscJars1.mkString(",")), Spark, livyConf)
       // if rsc jars are configured both in LivyConf and RSCConf, RSCConf should take precedence.
       properties1(RSCConf.Entry.LIVY_JARS.key()).split(",").toSet === rscJars1
+    }
+
+    it("should set datanucleus jars through livy conf") {
+      val datanucleusJars = Set(
+        "dummy.jar",
+        "local:///dummy-path/dummy1.jar",
+        "file:///dummy-path/dummy2.jar",
+        "hdfs:///dummy-path/dummy3.jar")
+      val livyConf = new LivyConf(false)
+        .set(LivyConf.ENABLE_HIVE_CONTEXT, true)
+        .set(LivyConf.REPL_JARS, "dummy.jar")
+        .set(LivyConf.RSC_JARS, "dummy2.jar")
+        .set(LivyConf.DATANUCLEUS_JARS, datanucleusJars.mkString(","))
+        .set(LivyConf.LIVY_SPARK_VERSION, sys.env("LIVY_SPARK_VERSION"))
+        .set(LivyConf.LIVY_SPARK_SCALA_VERSION, "2.10")
+      val properties = InteractiveSession.prepareBuilderProp(Map.empty, Spark, livyConf)
+      properties(LivyConf.SPARK_JARS).split(",").toSet should equal(datanucleusJars)
     }
 
     it("should update appId and appInfo and session store") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable usage of local jars for Dataneucleus instead of uploading them to HDFS to speed up YARN container startup times.

## How was this patch tested?

Deploying the jars to a test machine and running test jobs.
