### PR TITLE
[HOPSWORKS-1081][Append] exclude breaking dependencies from package

### DIFF
--- a/rsc/pom.xml
+++ b/rsc/pom.xml
@@ -114,6 +114,13 @@
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Exclude scala-library jar from rsc/jars. This jar was breaking Jupyter jobs.

## How was this patch tested?

Packaged Livy, deployed a VM, and run a PySpark 1+2 job
