### PR TITLE
[HOPSWORKS-1709] Bump-up Hops dependency version and add profile for provided Hops jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
   </mailingLists>
 
   <properties>
-    <hadoop.version>2.8.2.8</hadoop.version>
+    <hadoop.version>2.8.2.10-SNAPSHOT</hadoop.version>
     <hadoop.scope>compile</hadoop.scope>
     <spark.scala-2.11.version>2.2.0</spark.scala-2.11.version>
     <spark.version>${spark.scala-2.11.version}</spark.version>
@@ -1149,6 +1149,12 @@
       </build>
     </profile>
 
+    <profile>
+      <id>hadoop-provided</id>
+      <properties>
+        <hadoop.scope>provided</hadoop.scope>
+      </properties>
+    </profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a maven profile which will set the scope of Hops jars to provided

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

https://logicalclocks.atlassian.net/browse/HOPSWORKS-1709

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
